### PR TITLE
WIP: ADB: Setting usb flag correctly

### DIFF
--- a/recipes-modem/openqti/files/src/atfwd.c
+++ b/recipes-modem/openqti/files/src/atfwd.c
@@ -18,7 +18,7 @@
 #include "../inc/openqti.h"
 
 /* Used to keep track of the enabled USB composite configuration */
-int current_usb_mode = 0;
+int current_usb_mode = 1;
 
 void build_atcommand_reg_request(int tid, const char *command, char *buf) {
   struct atcmd_reg_request *atcmd;


### PR DESCRIPTION
Now we disable ADB persistently at standard boottime, this  variable is not tracking correctly anymore.
This patch sets it to the correct value at initial boot.