### PR TITLE
Experimental, almost-mainline LK bootloader building support from bitbake

### DIFF
--- a/recipes-bootloader/aboot/aboot.bb
+++ b/recipes-bootloader/aboot/aboot.bb
@@ -3,13 +3,15 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 inherit deploy
+
 DESCRIPTION = "LK2ND: Little Kernel Bootloader for Qcom SoCs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/\
 ${LICENSE};md5=0835ade698e0bcf8506ecda2f7b4f302"
+RPROVIDES_${PN} = "aboot"
+
 # We tell yocto what does this provide
-PROVIDES = "aboot"
-PROVIDES+= "virtual/bootloader"
+PROVIDES = "virtual/bootloader"
 
 # Set the project name
 ABOOT_PROJECT = "mdm9607"
@@ -17,13 +19,16 @@ ABOOT_PROJECT = "mdm9607"
 DEPENDS += "libgcc" 
 
 # Base paths
-SRC_URI   =  "git://github.com/Biktorgj/lk2nd.git;protocol=https;branch=fastboot_timer_test"
+SRC_URI   =  "git://github.com/Biktorgj/lk2nd.git;protocol=https;branch=quectel-eg25-timer"
 SRCREV = "${AUTOREV}"
 S = "${WORKDIR}/git"
+PV = "1.0+git-${SRCPV}"
 
-PR = "${DISTRO}"
-PVBASE := "${PV}"
-PV = "1.0+git${SRCPV}"
+# Force bitbake to always rebuild and reinstall
+# Otherwise unless you really clean everything it won't automatically
+# build it again until there's a change in the repo
+do_compile[nostamp] = "1"
+do_install[nostamp] = "1"
 
 # I need to find a better way for this or it will break on next release
 LIBGCC = "${STAGING_LIBDIR}/${TARGET_SYS}/11.2.0/libgcc.a"
@@ -32,9 +37,9 @@ LIBGCC = "${STAGING_LIBDIR}/${TARGET_SYS}/11.2.0/libgcc.a"
 LKSETTINGS = "SIGNED_KERNEL=0 DEBUG=1 ENABLE_DISPLAY=0 WITH_DEBUG_UART=1 BOARD=9607 SMD_SUPPORT=1 MMC_SDHCI_SUPPORT=0"
 
 # What actually gets run
-EXTRA_OEMAKE = "${ABOOT_PROJECT} -C ${S} O=${B} LIBGCC='${LIBGCC}' ENABLE_HARD_FPU=1 TOOLCHAIN_PREFIX=${TARGET_PREFIX} ${LKSETTINGS}"
+EXTRA_OEMAKE = "${ABOOT_PROJECT} -C ${S} LIBGCC='${LIBGCC}' ENABLE_HARD_FPU=1 TOOLCHAIN_PREFIX=${TARGET_PREFIX} ${LKSETTINGS}"
 
 do_install() {
 	install -d ${DEPLOY_DIR_IMAGE}
-	install ${S}/build-${ABOOT_PROJECT}/appsboot.mbn ${DEPLOY_DIR_IMAGE}/
+	install ${B}/build-${ABOOT_PROJECT}/appsboot.mbn ${DEPLOY_DIR_IMAGE}/
 }


### PR DESCRIPTION
As we move closer to replacing the older bootloader with a new, almost-mainline version, it's a perfect time to do some cleanup.
Currently this is my fork with some added patches to handle some missing bits in the LK codebase for mdm9x07, and with the fastboot timer implemented, but hopefully, we'll be able to merge these changes into upstream lk2nd project.
** THIS IS EXPERIMENTAL **
Use this recipe to build aboot from bitbake, which allows to ditch both the 'quectel_lk' repo, and the arm toolchain installed separate from Yocto just for that.
This allows to fully build the modem firmware from a non-x86 host

Thank you to Minecrell for your amazing work on lk2nd!