### PR TITLE
Openqti: Thermal monitoring, reporting and emergency shutdown support

### DIFF
--- a/recipes-modem/openqti/files/inc/thermal.h
+++ b/recipes-modem/openqti/files/inc/thermal.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef _THERMAL_H_
+#define _THERMAL_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define NO_OF_SENSORS 6
+#define THRM_ZONE_PATH "/sys/devices/virtual/thermal/thermal_zone"
+#define THRM_ZONE_TRAIL "/temp"
+
+void *thermal_monitoring_thread();
+
+#endif

--- a/recipes-modem/openqti/files/src/openqti.c
+++ b/recipes-modem/openqti/files/src/openqti.c
@@ -25,6 +25,7 @@
 #include "../inc/sms.h"
 #include "../inc/timesync.h"
 #include "../inc/tracking.h"
+#include "../inc/thermal.h"
 
 /*
  * OpenQTI
@@ -44,7 +45,7 @@ int main(int argc, char **argv) {
   pthread_t time_sync_thread;
   pthread_t pwrkey_thread;
   pthread_t scheduler_thread;
-
+  pthread_t thermal_thread;
   struct node_pair rmnet_nodes;
   rmnet_nodes.allow_exit = false;
 
@@ -238,6 +239,11 @@ int main(int argc, char **argv) {
   if ((ret = pthread_create(&scheduler_thread, NULL, &start_scheduler_thread,
                             NULL))) {
     logger(MSG_ERROR, "%s: Error creating scheduler thread\n", __func__);
+  }
+    logger(MSG_INFO, "%s: Init: Create Thermal monitor thread \n", __func__);
+  if ((ret = pthread_create(&thermal_thread, NULL, &thermal_monitoring_thread,
+                            NULL))) {
+    logger(MSG_ERROR, "%s: Error creating thermal monitor thread\n", __func__);
   }
 
   logger(MSG_INFO, "%s: Switching to powersave mode\n", __func__);

--- a/recipes-modem/openqti/files/src/thermal.c
+++ b/recipes-modem/openqti/files/src/thermal.c
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+#include "../inc/thermal.h"
+#include "../inc/call.h"
+#include "../inc/cell.h"
+#include "../inc/config.h"
+#include "../inc/helpers.h"
+#include "../inc/logger.h"
+#include "../inc/openqti.h"
+#include "../inc/qmi.h"
+#include "../inc/scheduler.h"
+#include "../inc/sms.h"
+#include <endian.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+// SPDX-License-Identifier: MIT
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <syscall.h>
+#include <linux/reboot.h>
+
+int get_temperature(char *sensor_path) {
+  int fd, val = 0;
+  char readval[6];
+  fd = open(sensor_path, O_RDONLY);
+  if (fd < 0) {
+    logger(MSG_ERROR, "%s: Cannot open sysfs entry %s\n", __func__,
+           sensor_path);
+    return -EINVAL;
+  }
+  lseek(fd, 0, SEEK_SET);
+  read(fd, &readval, 6);
+  val = strtol(readval, NULL, 10);
+
+  close(fd);
+  return val;
+}
+
+void *thermal_monitoring_thread() {
+  int sensors[7] = {0};
+  int prev_sensor_reading[7] = {0};
+  char sensor_path[128];
+  int i;
+  uint8_t *reply = calloc(160, sizeof(unsigned char));
+  int msglen;
+  bool notified_emergency = false;
+  bool notified_warning = false;
+  int round = 0;
+  int last_notify_round = 0;
+  logger(MSG_INFO, "Thermal monitor thread started\n");
+  while (1) {
+
+    for (i = 0; i < NO_OF_SENSORS; i++) {
+      snprintf(sensor_path, sizeof(sensor_path), "%s%i%s", THRM_ZONE_PATH, i,
+               THRM_ZONE_TRAIL);
+      prev_sensor_reading[i] = sensors[i];
+      sensors[i] = get_temperature(sensor_path);
+
+    }
+    logger(MSG_INFO, "Thermal zones 0-6: %iC %iC %iC %iC %iC %iC %iC \n", 
+    sensors[0], sensors[1], sensors[2], sensors[3], sensors[4], sensors[5], sensors[6]);
+
+    for (i = 0; i < NO_OF_SENSORS; i++) {
+      if (prev_sensor_reading[i] != 0 && sensors[i] != 0) {
+        if (sensors[i] > 85) {
+          msglen = snprintf((char *)reply, MAX_MESSAGE_SIZE,
+                            "I'm at %iC, I will shutdown now to help the phone cool down. Restart eg25-manager to power me up again\n",
+                            sensors[i]);
+          add_message_to_queue(reply, msglen);
+          last_notify_round = round;
+          notified_emergency = true;
+          sleep(5);
+                 syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
+                  LINUX_REBOOT_CMD_RESTART, NULL);
+        } 
+        if (sensors[i] > 75 && !notified_emergency) {
+          msglen = snprintf((char *)reply, MAX_MESSAGE_SIZE,
+                            "I'm starting to overheat!\nIf temperature keeps raising I will shut down soon (Sensor %i, Current temperature: %i ºC)\n",
+                            i, sensors[i]);
+          add_message_to_queue(reply, msglen);
+          last_notify_round = round;
+          notified_emergency = true;
+        } else if (sensors[i] > 60 && !notified_warning) {
+          msglen = snprintf((char *)reply, MAX_MESSAGE_SIZE,
+                            "It's getting hot in here... (Sensor %i, Current "
+                            "temperature: %iC)\n",
+                            i, sensors[i]);
+          add_message_to_queue(reply, msglen);
+          last_notify_round = round;
+          notified_warning = true;
+        } else if (sensors[i] - prev_sensor_reading[i] > 10) {
+          msglen = snprintf(
+              (char *)reply, MAX_MESSAGE_SIZE,
+              "Temperature is rapidly increasing\nSensor %i:\n  Current "
+              "temperature: %iC\n  Previous temperature: %iC\n",
+              i, sensors[i], prev_sensor_reading[i]);
+          add_message_to_queue(reply, msglen);
+          last_notify_round = round;
+        }
+      }
+    }
+
+    sleep(5);
+    round++;
+    if (round - last_notify_round > 60) { 
+      notified_emergency = false;
+      notified_warning = false;
+    }
+  }
+
+  return 0;
+}

--- a/recipes-modem/openqti/openqti.bb
+++ b/recipes-modem/openqti/openqti.bb
@@ -25,6 +25,7 @@ SRC_URI = "file://inc/openqti.h \
            file://inc/timesync.h \
            file://inc/scheduler.h \
            file://inc/config.h \
+           file://inc/thermal.h \
            file://src/qmi.c \
            file://src/tracking.c \
            file://src/helpers.c \
@@ -47,14 +48,16 @@ SRC_URI = "file://inc/openqti.h \
            file://src/pico2aud.c \
            file://src/scheduler.c \
            file://src/config.c \
+           file://src/thermal.c \
            file://init_openqti \
            file://external/ring8k.wav \
            file://thankyou/thankyou.txt"
+           
 S = "${WORKDIR}"
 FILES:${PN} += "/usr/share/tones/*"
 FILES:${PN} += "/usr/share/thank_you/*"
 do_compile() {
-    ${CC} ${LDFLAGS} -O2 src/config.c src/scheduler.c src/pico2aud.c src/qmi.c src/timesync.c src/cell.c src/call.c src/command.c src/proxy.c src/sms.c src/tracking.c src/helpers.c src/atfwd.c src/logger.c src/md5sum.c src/ipc.c src/audio.c src/mixer.c src/pcm.c src/openqti.c -o openqti -lpthread -lttspico
+    ${CC} ${LDFLAGS} -O2 src/thermal.c src/config.c src/scheduler.c src/pico2aud.c src/qmi.c src/timesync.c src/cell.c src/call.c src/command.c src/proxy.c src/sms.c src/tracking.c src/helpers.c src/atfwd.c src/logger.c src/md5sum.c src/ipc.c src/audio.c src/mixer.c src/pcm.c src/openqti.c -o openqti -lpthread -lttspico
 }
 
 do_install() {


### PR DESCRIPTION
This moves the old "datalogger" into openqti, and adds messaging and shutdown support.

At more than 70 degrees, it will send the first warning.
If you keep heating the phone, at 80C or more, it will issue a second warning, and at 85C the modem will send one last message before powering down automatically to help mitigate the heat.

The messages are rate limited, it will send one message of each type every 5 minutes