### PR TITLE
Automatic handling of calls while you're already talking

### DIFF
--- a/recipes-modem/openqti/files/inc/audio.h
+++ b/recipes-modem/openqti/files/inc/audio.h
@@ -51,34 +51,6 @@ enum {
   VOIP_SESSION_VSID = 0x10004000,
 };
 
-enum call_direction {
-  AUDIO_DIRECTION_OUTGOING = 0x01,
-  AUDIO_DIRECTION_INCOMING = 0x02,
-};
-
-enum call_status {
-  AUDIO_CALL_NOT_STARTED_YET = 0x00,
-  AUDIO_CALL_ORIGINATING = 0x01,
-  AUDIO_CALL_RINGING = 0x02,
-  AUDIO_CALL_ESTABLISHED = 0x03,
-  AUDIO_CALL_ATTEMPT = 0x04,
-  AUDIO_CALL_ALERTING = 0x05,
-  AUDIO_CALL_ON_HOLD = 0x06,
-  AUDIO_CALL_WAITING = 0x07,
-  AUDIO_CALL_DISCONNECTING = 0x08,
-  AUDIO_CALL_HANGUP = 0x09,
-  AUDIO_CALL_PREPARING = 0x0a
-};
-
-enum call_type {
-  CALL_TYPE_NO_NETWORK = 0x00,
-  CALL_TYPE_UNKNOWN = 0x01,
-  CALL_TYPE_GSM = 0x02,
-  CALL_TYPE_UMTS = 0x03,
-  CALL_TYPE_VOLTE = 0x04,
-  CALL_TYPE_UNKNOWN_ALT = 0x05 // this I don't know what it is
-};
-
 /* AUDIO */
 
 enum ctl_type {
@@ -226,8 +198,7 @@ int set_mixer_ctl(struct mixer *mixer, char *name, int value);
 int mixer_ctl_set_gain(struct mixer_ctl *ctl, int call_type, int value);
 int stop_audio();
 int start_audio(int type);
-void handle_call_pkt(struct call_status_indication *pkt, int sz,
-                     uint8_t *phone_number);
+void handle_call_pkt(uint8_t *pkt, int sz);
 int set_audio_defaults();
 int set_external_codec_defaults();
 void set_auxpcm_sampling_rate(uint8_t mode);

--- a/recipes-modem/openqti/files/inc/command.h
+++ b/recipes-modem/openqti/files/inc/command.h
@@ -53,6 +53,9 @@ static const struct {
     {30, "about", "", "Info about the firmware"},
     {31, "enable cell broadcast", "Enabling Cell broadcasting for index 0-6000...", "Enables Cell broadcasting messages"},
     {32, "disable cell broadcast", "Disabling cell broadcast...", "Disables Cell broadcasting messages"},
+    {33, "callwait auto hangup", "I will automatically terminate all incoming calls while you're talking", "Automatically kills any new incoming call while you're talking"},
+    {34, "callwait auto ignore", "I will just inform you that there's a new call waiting", "Automatically ignores any new incoming call while you're talking"},
+    {35, "callwait mode default", "I will let the host handle multiple calls", "Disables automatic hang up of incoming calls while you're talking"},
 };
 
 static const struct {

--- a/recipes-modem/openqti/files/inc/config.h
+++ b/recipes-modem/openqti/files/inc/config.h
@@ -17,6 +17,7 @@ struct config_prototype {
   char modem_name[MAX_NAME_SZ];
   uint8_t signal_tracking;
   uint8_t sms_logging;
+  uint8_t callwait_autohangup;
   bool first_boot;
 };
 
@@ -53,5 +54,9 @@ void clear_ifrst_boot_flag();
 /* SMS logging */
 int is_sms_logging_enabled();
 void set_sms_logging(bool en);
+
+/* Automatically hang up call waiting */
+int callwait_auto_hangup_operation_mode();
+void enable_call_waiting_autohangup(uint8_t en);
 
 #endif

--- a/recipes-modem/openqti/files/inc/logger.h
+++ b/recipes-modem/openqti/files/inc/logger.h
@@ -17,5 +17,5 @@ uint8_t get_log_level();
 void set_log_level(uint8_t level);
 void set_log_method(bool ttyout);
 void dump_pkt_raw(uint8_t *buf, int pktsize);
-int mask_phone_number(char *orig, char *dest);
+int mask_phone_number(uint8_t *orig, char *dest, uint8_t len);
 #endif

--- a/recipes-modem/openqti/files/inc/openqti.h
+++ b/recipes-modem/openqti/files/inc/openqti.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define RELEASE_VER "0.6.5"
+#define RELEASE_VER "0.6.6"
 
 #define MSG_DEBUG 0
 #define MSG_INFO 1

--- a/recipes-modem/openqti/files/inc/qmi.h
+++ b/recipes-modem/openqti/files/inc/qmi.h
@@ -20,8 +20,7 @@ struct qmux_packet {      // 6 byte
 struct qmi_packet { // 7 byte
   uint8_t ctlid;    // 0x00 | 0x02 | 0x04, subsystem inside message service?
   uint16_t transaction_id; // QMI Transaction ID
-  uint16_t
-      msgid; // 0x0022 when message arrives, 0x0002 when there are new messages
+  uint16_t msgid; // QMI Message ID
   uint16_t length; // QMI Packet size
 } __attribute__((packed));
 

--- a/recipes-modem/openqti/files/src/call.c
+++ b/recipes-modem/openqti/files/src/call.c
@@ -4,6 +4,7 @@
 #include "../inc/atfwd.h"
 #include "../inc/audio.h"
 #include "../inc/command.h"
+#include "../inc/config.h"
 #include "../inc/devices.h"
 #include "../inc/helpers.h"
 #include "../inc/ipc.h"
@@ -156,8 +157,9 @@ void send_call_request_response(int usbfd, uint16_t transaction_id) {
 uint8_t send_voice_call_status_event(int usbfd, uint16_t transaction_id,
                                      uint8_t call_direction,
                                      uint8_t call_state) {
-  logger(MSG_DEBUG, "%s: Send QMI call status message: Direction %i, state %i\n",
-         __func__, call_direction, call_state);
+  logger(MSG_DEBUG,
+         "%s: Send QMI call status message: Direction %i, state %i\n", __func__,
+         call_direction, call_state);
   uint8_t phone_proto[] = {0x2b, 0x32, 0x32, 0x33, 0x33, 0x34, 0x34,
                            0x35, 0x35, 0x36, 0x36, 0x37, 0x37};
   struct simulated_call_packet *pkt;
@@ -186,14 +188,13 @@ uint8_t send_voice_call_status_event(int usbfd, uint16_t transaction_id,
   /* META */
   pkt->meta.tlvid = 0x01;
   pkt->meta.length = 0x08;
-  pkt->meta.unk1 = 0x01;
-  pkt->meta.unk2 = 0x01;
+  pkt->meta.num_instances = 0x01;
+  pkt->meta.call_id = 0x01;
   pkt->meta.call_state = call_state;
-  pkt->meta.unk4 = 0x02;
   pkt->meta.call_direction = call_direction;
-  pkt->meta.call_type = CALL_TYPE_VOLTE;
-  pkt->meta.unk7 = 0x00;
-  pkt->meta.unk8 = 0x00;
+  pkt->meta.call_mode = CALL_MODE_VOLTE;
+  pkt->meta.is_multiparty = 0x00;
+  pkt->meta.als = 0x00;
 
   /* REMOTE PARTY NUMBER */
   pkt->number.tlvid = 0x10;
@@ -275,10 +276,10 @@ void accept_simulated_call(int usbfd, uint8_t transaction_id) {
 void close_internal_call(int usbfd, uint16_t transaction_id) {
   send_voice_call_status_event(usbfd, transaction_id,
                                call_rt.sim_call_direction,
-                               AUDIO_CALL_DISCONNECTING);
+                               CALL_STATE_DISCONNECTING);
   usleep(100000);
   send_voice_call_status_event(usbfd, transaction_id + 1,
-                               call_rt.sim_call_direction, AUDIO_CALL_HANGUP);
+                               call_rt.sim_call_direction, CALL_STATE_HANGUP);
 
   set_call_simulation_mode(false);
   call_rt.sim_call_direction = 0;
@@ -288,14 +289,14 @@ void start_simulated_call(int usbfd) {
   pthread_t kill_timeout_thread;
   int ret;
   call_rt.transaction_id = 0x01;
-  call_rt.simulated_call_state = AUDIO_CALL_RINGING;
-  call_rt.sim_call_direction = AUDIO_DIRECTION_INCOMING;
+  call_rt.simulated_call_state = CALL_STATE_RINGING;
+  call_rt.sim_call_direction = CALL_DIRECTION_INCOMING;
   set_call_simulation_mode(true);
   pulse_ring_in();
   usleep(300000); // try with 300ms
   logger(MSG_WARN, " Call update notification: RINGING to %x\n", usbfd);
   send_voice_call_status_event(usbfd, call_rt.transaction_id,
-                               AUDIO_DIRECTION_INCOMING, AUDIO_CALL_RINGING);
+                               CALL_DIRECTION_INCOMING, CALL_STATE_RINGING);
 }
 
 uint8_t send_voice_cal_disconnect_ack(int usbfd, uint16_t transaction_id) {
@@ -347,7 +348,7 @@ void notify_simulated_call(int usbfd) {
     reset_call_state();
   }
 
-  if (call_rt.simulated_call_state != AUDIO_CALL_ESTABLISHED) {
+  if (call_rt.simulated_call_state != CALL_STATE_ESTABLISHED) {
     if (call_rt.timeout_counter > 60) {
       logger(MSG_INFO, "%s: Killing internal call\n", __func__);
       close_internal_call(usbfd, call_rt.transaction_id);
@@ -495,8 +496,7 @@ void process_incoming_call_accept(int usbfd, uint16_t transaction_id) {
   accept_simulated_call(usbfd, transaction_id);
   usleep(100000);
   send_voice_call_status_event(usbfd, transaction_id + 1,
-                               AUDIO_DIRECTION_INCOMING,
-                               AUDIO_CALL_ESTABLISHED);
+                               CALL_DIRECTION_INCOMING, CALL_STATE_ESTABLISHED);
   usleep(100000);
   if ((ret = pthread_create(&dummy_echo_thread, NULL,
                             &simulated_call_tts_handler, NULL))) {
@@ -508,21 +508,21 @@ void send_dummy_call_established(int usbfd, uint16_t transaction_id) {
   pthread_t dummy_echo_thread;
   int ret;
   logger(MSG_DEBUG, "%s: Sending response: ATTEMPT\n", __func__);
-  send_voice_call_status_event(usbfd, transaction_id, AUDIO_DIRECTION_OUTGOING,
-                               AUDIO_CALL_ATTEMPT);
+  send_voice_call_status_event(usbfd, transaction_id, CALL_DIRECTION_OUTGOING,
+                               CALL_STATE_ATTEMPT);
   usleep(100000);
   logger(MSG_DEBUG, "%s: Sending response: Call request ACK \n", __func__);
   send_call_request_response(usbfd, transaction_id);
   usleep(100000);
   logger(MSG_DEBUG, "%s: Sending response: ALERTING\n", __func__);
   transaction_id++;
-  send_voice_call_status_event(usbfd, transaction_id, AUDIO_DIRECTION_OUTGOING,
-                               AUDIO_CALL_ALERTING);
+  send_voice_call_status_event(usbfd, transaction_id, CALL_DIRECTION_OUTGOING,
+                               CALL_STATE_ALERTING);
   usleep(100000);
   logger(MSG_DEBUG, "%s: Sending response: ESTABLISHED\n", __func__);
   transaction_id++;
-  send_voice_call_status_event(usbfd, transaction_id, AUDIO_DIRECTION_OUTGOING,
-                               AUDIO_CALL_ESTABLISHED);
+  send_voice_call_status_event(usbfd, transaction_id, CALL_DIRECTION_OUTGOING,
+                               CALL_STATE_ESTABLISHED);
   usleep(100000);
   if ((ret = pthread_create(&dummy_echo_thread, NULL,
                             &simulated_call_tts_handler, NULL))) {
@@ -531,9 +531,69 @@ void send_dummy_call_established(int usbfd, uint16_t transaction_id) {
 
   call_rt.transaction_id = transaction_id; // Save the current transaction ID
 }
+
+uint8_t get_num_instances(void *bytes, size_t len) {
+  uint8_t instances = 0;
+  struct call_status_meta *meta;
+  int offset = get_tlv_offset_by_id((uint8_t *)bytes, len, TLV_CALL_INFO);
+  if (offset <= 0) {
+    logger(MSG_ERROR, "%s:Couldn't retrieve call metadata \n", __func__);
+  } else if (offset > 0) {
+    meta = (struct call_status_meta *)(bytes + offset);
+    instances = meta->num_instances;
+    meta = NULL;
+  }
+  return instances;
+}
+
+uint8_t get_call_state(void *bytes, size_t len) {
+  uint8_t state = 0;
+  struct call_status_meta *meta;
+  int offset = get_tlv_offset_by_id((uint8_t *)bytes, len, TLV_CALL_INFO);
+  if (offset <= 0) {
+    logger(MSG_ERROR, "%s:Couldn't retrieve call metadata \n", __func__);
+  } else if (offset > 0) {
+    meta = (struct call_status_meta *)(bytes + offset);
+    state = meta->call_state;
+    meta = NULL;
+  }
+  return state;
+}
+
+// For user automatic call termination on call waiting
+void autokill_call(void *bytes, size_t len, uint8_t call_id, int adspfd) {
+  logger(MSG_WARN, "%s: Automaticall killing Waiting call with ID %i\n",
+         __func__, call_id);
+  struct encapsulated_qmi_packet *pkt = (struct encapsulated_qmi_packet *)bytes;
+  int new_transaction_id = pkt->qmi.transaction_id + 1;
+  struct call_hangup_request *request;
+  request = calloc(1, sizeof(struct call_hangup_request));
+  request->qmuxpkt.version = 0x01;
+  request->qmuxpkt.packet_length = 0x10;
+  request->qmuxpkt.control = 0x00;
+  request->qmuxpkt.service = 0x09;
+  request->qmuxpkt.instance_id = 0x02;
+  request->qmipkt.ctlid = 0x00;
+  request->qmipkt.transaction_id = pkt->qmi.transaction_id + 1;
+  request->qmipkt.msgid = VO_SVC_CALL_END_REQ;
+  request->qmipkt.length = 0x04;
+  request->call_id.id = 0x01;
+  request->call_id.len = 0x01;
+  request->call_id.data = call_id;
+
+  logger(MSG_INFO, "%s: Sending the payload to the baseband\n", __func__);
+  int bytes_written =
+      write(adspfd, request, sizeof(struct call_hangup_request));
+  logger(MSG_INFO, "%s: Payload *SENT*\n", __func__);
+
+  free(request);
+  request = NULL;
+  pkt = NULL;
+}
+
 uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
                              uint16_t msgid, int adspfd, int usbfd) {
-  int needs_rerouting = 0, i, j;
+  int needs_rerouting = 0, i, j, offset;
   struct encapsulated_qmi_packet *pkt;
   struct call_request_indication *req;
   struct call_status_indication *ind;
@@ -541,7 +601,10 @@ uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
   pkt = (struct encapsulated_qmi_packet *)bytes;
   uint8_t our_phone[] = {0x32, 0x32, 0x33, 0x33, 0x34, 0x34,
                          0x35, 0x35, 0x36, 0x36, 0x37, 0x37};
-  // We need the original number to keep track of its state                         
+
+  uint8_t *reply = calloc(MAX_MESSAGE_SIZE, sizeof(unsigned char));
+
+  // We need the original number to keep track of its state
   uint8_t phone_number[MAX_PHONE_NUMBER_LENGTH];
   memset(phone_number, 0, MAX_PHONE_NUMBER_LENGTH);
   // But we also dont need to log it to disk unless requested
@@ -560,20 +623,20 @@ uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
         j++;
       }
     }
-    mask_phone_number(phone_number, log_phone_number);
+    mask_phone_number(phone_number, log_phone_number, j);
     if (j > 0 && memcmp(phone_number, our_phone, 12) == 0) {
-      logger(MSG_INFO, "%s: This call is for me: %s\n", __func__, log_phone_number);
+      logger(MSG_INFO, "%s: This call is for me: %s\n", __func__,
+             log_phone_number);
       if (!get_call_simulation_mode()) {
         set_call_simulation_mode(true);
         send_dummy_call_established(usbfd, req->qmipkt.transaction_id);
-        call_rt.sim_call_direction = AUDIO_DIRECTION_OUTGOING;
+        call_rt.sim_call_direction = CALL_DIRECTION_OUTGOING;
       } else {
         logger(MSG_ERROR, "%s: We're already talking!\n", __func__);
       }
       needs_rerouting = 1;
     } else {
-      logger(MSG_INFO, "%s: Outgoing call to %s\n", __func__,
-             log_phone_number);
+      logger(MSG_INFO, "%s: Outgoing call to %s\n", __func__, log_phone_number);
       if (get_call_simulation_mode()) {
         logger(MSG_WARN, "%s: Ending internal call first\n", __func__);
         close_internal_call(usbfd, pkt->qmi.transaction_id);
@@ -598,31 +661,67 @@ uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
     break;
 
   case VO_SVC_CALL_STATUS:
-    ind = (struct call_status_indication *)bytes;
-    j = 0;
-    for (i = 0; i < ind->number.phone_num_length; i++) {
-      if (ind->number.phone_number[i] >= 0x30 &&
-          ind->number.phone_number[i] <= 0x39) {
-        phone_number[j] = ind->number.phone_number[i];
-        j++;
+    offset = get_tlv_offset_by_id((uint8_t *)bytes, len, TLV_REMOTE_NUMBER);
+    int info_offset =
+        get_tlv_offset_by_id((uint8_t *)bytes, len, TLV_CALL_INFO);
+    if (offset <= 0) {
+      logger(MSG_ERROR, "%s:Couldn't retrieve remote number data \n", __func__);
+    } else if (offset > 0) {
+      struct remote_party *rmtparty;
+      rmtparty = (struct remote_party *)(bytes + offset);
+      logger(MSG_DEBUG, "Size %i , Call instances: %i\n", rmtparty->length,
+             get_num_instances(bytes, len));
+      struct remote_party_data *thisnum;
+      int prev_num_size = 0;
+      for (int i = 0; i < get_num_instances(bytes, len); i++) {
+        if (i == 0) {
+          /* We start at remote_party + id + len + first_entry */
+          thisnum = (struct remote_party_data *)(bytes + offset + 3);
+          memcpy(phone_number, thisnum->phone, thisnum->len);
+          mask_phone_number(phone_number, log_phone_number, thisnum->len);
+          logger(MSG_INFO, "%s: Call #%i: %s\n", __func__, i, log_phone_number);
+          prev_num_size += thisnum->len + 3;
+
+          if (get_num_instances(bytes, len) > 1 &&
+              get_call_state(bytes, len) == CALL_STATE_WAITING) {
+            if (callwait_auto_hangup_operation_mode() == 2) {
+              int strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE, "Automatically rejecting the call from %s while you're talking\n", phone_number);
+              add_sms_to_queue(reply, strsz);
+              autokill_call(bytes, len, thisnum->call_id, adspfd);
+            } else {
+              int strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE, "Call from %s while you're talking (ignoring it) \n", phone_number);
+              add_sms_to_queue(reply, strsz);
+            }
+          }
+        } else {
+          thisnum =
+              (struct remote_party_data *)(bytes + offset + 3 + prev_num_size);
+          memcpy(phone_number, thisnum->phone, thisnum->len);
+          mask_phone_number(phone_number, log_phone_number, thisnum->len);
+          logger(MSG_INFO, "%s: Call #%i: %s\n", __func__, i, log_phone_number);
+          if (callwait_auto_hangup_operation_mode() > 0) {
+            needs_rerouting = 1;
+          }
+        }
+        j = thisnum->len;
+        thisnum = NULL;
       }
+      rmtparty = NULL;
     }
-    mask_phone_number(phone_number, log_phone_number);
 
     /* Caller ID is set */
     if (j > 0) {
-      logger(MSG_INFO, "%s: Call status for %s\n", __func__, log_phone_number);
       if (memcmp(phone_number, our_phone, 12) == 0) {
-        logger(MSG_INFO, "%s: Internal call\n", __func__);
+        logger(MSG_DEBUG, "%s: Internal call\n", __func__);
         needs_rerouting = 1;
       } else {
         if (get_call_simulation_mode()) {
           logger(MSG_WARN,
-                 "%s: Request is for a different number, ending call\n",
+                 "%s: New call while internally talking, ending simulated call\n",
                  __func__);
           close_internal_call(usbfd, pkt->qmi.transaction_id);
         }
-        handle_call_pkt(bytes, len, phone_number);
+        handle_call_pkt(bytes, len);
       }
     } else {
       /* Caller ID is *NOT* set */
@@ -632,16 +731,17 @@ uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
         logger(MSG_WARN, "%s: Unknown number %s\n", __func__, log_phone_number);
         memcpy((uint8_t *)phone_number, (uint8_t *)"Unknown",
                strlen("Unknown"));
-        handle_call_pkt(bytes, len, phone_number);
+        handle_call_pkt(bytes, len);
       }
     }
-    ind = NULL;
     break;
 
   case VO_SVC_GET_ALL_CALL_INFO: /* FIXME: IMPLEMENT THIS */
     logger(MSG_INFO, "%s: VO_SVC_GET_ALL_CALL_INFO: Unimplemented\n", __func__);
     set_log_level(0);
     dump_pkt_raw(bytes, len);
+    set_log_level(1);
+
     break;
 
   case VO_SVC_CALL_STATUS_CHANGE:
@@ -665,6 +765,7 @@ uint8_t call_service_handler(uint8_t source, void *bytes, size_t len,
     break;
   }
 
+  free(reply);
   pkt = NULL;
   return needs_rerouting;
 }

--- a/recipes-modem/openqti/files/src/command.c
+++ b/recipes-modem/openqti/files/src/command.c
@@ -1234,7 +1234,24 @@ uint8_t parse_command(uint8_t *command) {
   case 32:
     set_cb_broadcast(false);
     break;
-    
+  case 33:
+        strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE, "%s\n",
+                     bot_commands[cmd_id].cmd_text);
+    add_message_to_queue(reply, strsz);
+    enable_call_waiting_autohangup(2);
+    break;
+  case 34:
+      strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE, "%s\n",
+                     bot_commands[cmd_id].cmd_text);
+    add_message_to_queue(reply, strsz);
+    enable_call_waiting_autohangup(1);
+    break;
+  case 35:
+      strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE, "%s\n",
+                     bot_commands[cmd_id].cmd_text);
+    add_message_to_queue(reply, strsz);
+    enable_call_waiting_autohangup(0);
+    break;
   case 100:
     set_custom_modem_name(command);
     break;

--- a/recipes-modem/openqti/files/src/logger.c
+++ b/recipes-modem/openqti/files/src/logger.c
@@ -152,19 +152,18 @@ void dump_pkt_raw(uint8_t *buf, int pktsize) {
   }
 }
 
-int mask_phone_number(char *orig, char *dest) {
-  int orig_size = strlen(orig);
-  if (orig_size < 1) {
+int mask_phone_number(uint8_t *orig, char *dest, uint8_t len) {
+  if (len < 1) {
     snprintf(dest, MAX_PHONE_NUMBER_LENGTH, "[none]");
     return -1;
   }
   snprintf(dest, MAX_PHONE_NUMBER_LENGTH, "%s", orig);
   if (get_log_level() != MSG_DEBUG) {
-    for (int i = 0; i < (orig_size - 3); i++) {
+    for (int i = 0; i < (len - 3); i++) {
       dest[i] = '*';
     }
   }
 
-  logger(MSG_DEBUG, "%s: %s --> %s (%i)\n", __func__, orig, dest, orig_size);
+  logger(MSG_DEBUG, "%s: %s --> %s (%i)\n", __func__, orig, dest, len);
   return 0;
 }

--- a/recipes-modem/openqti/files/src/proxy.c
+++ b/recipes-modem/openqti/files/src/proxy.c
@@ -373,9 +373,8 @@ void *rmnet_proxy(void *node_data) {
     FD_ZERO(&readfds);
     memset(buf, 0, sizeof(buf));
     FD_SET(nodes->node2.fd, &readfds);      // Always add ADSP
-    if (!get_transceiver_suspend_state()) { // Only add USB if active
-      FD_SET(nodes->node1.fd, &readfds);
-    }
+    FD_SET(nodes->node1.fd, &readfds);      // Testing: add usb always too
+
     tv.tv_sec = 0;
     tv.tv_usec = 500000;
     ret = select(MAX_FD, &readfds, NULL, NULL, &tv);


### PR DESCRIPTION
This commits improves tracking and handling of call states. It also adds three commands to automatically handle incoming calls while there's already an active call and fixes a buffer overflow from mishandling the remote party number when multiple calls are active.
New options in the chat:
- callwait mode default: Let the host's userspace handle call waiting (same behaviour as before, some apps don't support call waiting and may crash)
- callwait auto ignore: Automatically send a message to the user informing about the call, but don't pass call notification to the host while another call is in progress. The other party will hear a dialing tone but the user will only get the message about the call. This avoids gnome-calls from crashing
- callwait auto hangup: Automatically send a message to the user informing about the call, and reject it. That way there can't be a ghost call if the user terminates the call before the other party hangs up. The call rejection will take about 1/2 tone, so the remote party may not see a *busy* but a hang up (depending on network)"
