### PR TITLE
Add dummy logcat script 

### DIFF
--- a/recipes-scripts/shared-scripts/files/logcat
+++ b/recipes-scripts/shared-scripts/files/logcat
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Welcome to the modem distro!"

--- a/recipes-scripts/shared-scripts/shared-scripts.bb
+++ b/recipes-scripts/shared-scripts/shared-scripts.bb
@@ -13,6 +13,7 @@ INHIBIT_PACKAGE_STRIP = "1"
 SRC_URI="file://adbd \
          file://recoverymount \
          file://log_rename.sh \
+         file://logcat \
          file://rootfsmount "
 
 S = "${WORKDIR}"
@@ -26,6 +27,7 @@ do_install() {
 
       install -m 0755 ${S}/adbd ${D}/etc/init.d/
       install -m 0755  ${S}/recoverymount ${D}/bin
+      install -m 0755  ${S}/logcat ${D}/bin
       install -m 0755  ${S}/rootfsmount ${D}/bin
       install -m 0755  ${S}/log_rename.sh ${D}/etc/init.d/
       ln -sf -r ${D}/etc/init.d/log_rename.sh ${D}/etc/rcS.d/S11log_rename.sh


### PR DESCRIPTION
Whenever I try I build, I like to keep adb blocked until the modem boots. I do this by calling `adb logcat ; adb shell tail -f [path]/openqti.log` to check on boot process.
As we don't really have a logcat binary, it would always complain at boot that the command wasn't found. This just adds a silly script