### PR TITLE
Ramdisk support 

### DIFF
--- a/conf/machine/include/mdm9607.inc
+++ b/conf/machine/include/mdm9607.inc
@@ -1,12 +1,8 @@
+
 SOC_FAMILY = "mdm9607"
+MACHINE = "mdm9607"
 require conf/machine/include/soc-family.inc
 require conf/machine/include/arm/armv7a/tune-cortexa8.inc
-
-PREFERRED_PROVIDER_virtual/kernel ?= "linuxmdm"
-
-MACHINE_EXTRA_RRECOMMENDS += " \
-    fastrpc \
-"
 
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
@@ -18,7 +14,7 @@ QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
 
 # Image Generation
 # Make ubi filesystem and then pack it in a ubi container, as stock
-IMAGE_FSTYPES ?= "ubi multiubi "
+IMAGE_FSTYPES ?= "ubi multiubi cpio cpio.gz"
 
 # Set the volume name inside the ubi image
 UBI_VOLNAME = "rootfs"

--- a/recipes-kernel/linuxmdm/linuxmdm.bb
+++ b/recipes-kernel/linuxmdm/linuxmdm.bb
@@ -10,6 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 # Set compatible machines for this kernel
 COMPATIBLE_MACHINE = "mdm9607"
+
 # Dependencies
 DEPENDS += "mkbootimg-native dtbtool-native libgcc dtc-native"
 
@@ -38,7 +39,7 @@ KERNEL_TAGS_ADDR = "0x81E00000"
 # For debugging through serial console:
 # KERNEL_CMDLINE = "noinitrd ro console=ttyHSL0,115200,n8 androidboot.hardware=qcom ehci-hcd.park=3 msm_rtb.filter=0x37 lpm_levels.sleep_disabled=1"
 # For Production use (faster)
-KERNEL_CMDLINE = "noinitrd ro androidboot.hardware=qcom ehci-hcd.park=3 msm_rtb.filter=0x37 lpm_levels.sleep_disabled=1"
+KERNEL_CMDLINE = "ro androidboot.hardware=qcom ehci-hcd.park=3 msm_rtb.filter=0x37 lpm_levels.sleep_disabled=1"
 
 # Uncomment this option if you want bitbake to force-rebuild the kernel
 # do_compile[nostamp] = "1"
@@ -93,7 +94,7 @@ priv_make_image() {
               --base ${QCOM_BOOTIMG_KERNEL_BASE} \
               --tags-addr ${KERNEL_TAGS_ADDR} \
               --dt ${B}/arch/arm/boot/dts/qcom/dtb.img \
-              --cmdline "${KERNEL_CMDLINE}"
+              --cmdline "noinitrd ${KERNEL_CMDLINE}"
 }
 
 do_deploy:append() {
@@ -108,4 +109,6 @@ do_deploy:append() {
 
     priv_make_image ${QCOM_BOOTIMG_ROOTFS} ${BOOT_IMAGE_BASE_NAME}
     ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
+	cp ${STAGING_BINDIR_NATIVE}/mkbootimg ${DEPLOYDIR}/mkbootimg
+	cp ${B}/arch/arm/boot/dts/qcom/dtb.img ${DEPLOYDIR}/dtb.img
 }


### PR DESCRIPTION
Make bitbake build ubifs and cpio.gz files when building core-image*
When building the kernel, also place latest built mkbootimg and adtb.img in the deploy folder, so they can be later picked up by the Makefile to make a kernel+dtb+ramdisk with the entire system