### PR TITLE
Replacing original log_rename.sh

### DIFF
--- a/recipes-scripts/shared-scripts/files/log_rename.sh
+++ b/recipes-scripts/shared-scripts/files/log_rename.sh
@@ -18,7 +18,6 @@ if [ -f "/persist/openqti.log" ]; then
     fi
     logNum=$((logNum - 1))
     logFiles[$logNum]="$logFile"
-    echo "Saved ${logFiles[${logNum}]} with index ${logNum}"
   done
   for ((i=${#logFiles[@]}; i>0; i--)); do
     [ $i -gt 20 ] && continue
@@ -53,7 +52,6 @@ if [ -f "/persist/thermal.log" ]; then
     fi
     logNum=$((logNum - 1))
     logFiles[$logNum]="$logFile"
-    echo "Saved ${logFiles[${logNum}]} with index ${logNum}"
   done
   for ((i=${#logFiles[@]}; i>0; i--)); do
     [ $i -gt 20 ] && continue


### PR DESCRIPTION
Migrating to a new log naming convention <logname>-<archivenumber>.log instead of <logname>.log.<archivenumber>. A rewrite was necessary to maintain backwards compatiblity with the old naming convention and rename old files to the new naming scheme