### PR TITLE
[sms/chat] Add new 'Say X' command

### DIFF
--- a/recipes-modem/openqti/files/inc/chat_helpers.h
+++ b/recipes-modem/openqti/files/inc/chat_helpers.h
@@ -89,6 +89,7 @@ enum {
   CMD_ID_ACTION_INTERNAL_NETWORK_SET_USER,
   CMD_ID_ACTION_INTERNAL_NETWORK_SET_PASS,
   CMD_ID_ACTION_INTERNAL_NETWORK_SET_AUTH_METHOD,
+  CMD_ID_ACTION_SAY_TEXT,
 };
 
 void cmd_get_rmnet_stats();
@@ -122,6 +123,7 @@ void cmd_configure_internal_network_auth_method(uint8_t *command);
 void cmd_configure_signal_tracking_cell_notification(uint8_t *command);
 void cmd_clear_internal_networking_auth();
 void cmd_set_cb_broadcast(bool en);
+void cmd_say_text(uint8_t *command);
 
 void cmd_get_openqti_log();
 void cmd_get_kernel_log();

--- a/recipes-modem/openqti/files/inc/command.h
+++ b/recipes-modem/openqti/files/inc/command.h
@@ -242,6 +242,8 @@ static const struct {
      "set internal network auth method ", "Set internal apn auth method ",
      "Configure your carrier APN authentication method (options: none, pap, "
      "chap, auto)"},
+     {CMD_ID_ACTION_SAY_TEXT, 1, CMD_CATEGORY_UTILITY, "say ",
+     "Say X", "Responds with X. If calling the modem, responds via Text To Speech"},
 };
 
 char *get_rt_modem_name();

--- a/recipes-modem/openqti/files/src/chat_helpers.c
+++ b/recipes-modem/openqti/files/src/chat_helpers.c
@@ -1630,3 +1630,43 @@ void cmd_thank_you() {
                    "every day, I wouldn't have a purpose without you all!");
   add_message_to_queue(reply, strsz);
 }
+
+/* Syntax:
+ * Say X
+ * Examples:
+ *  say Hello
+ *  say I am a robot
+ *  say Look, I can make my modem say things!
+ *
+ */
+void cmd_say_text(uint8_t *command) {
+  uint8_t *offset_command;
+  uint8_t *reply = calloc(MAX_MESSAGE_SIZE, sizeof(uint8_t));
+  int strsz = 0;
+
+  /* Initial command check */
+  offset_command = (uint8_t *)strstr(
+      (char *)command, bot_commands[CMD_ID_ACTION_SAY_TEXT].cmd);
+  if (offset_command == NULL) {
+    strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE - strsz,
+                     "Command mismatch!\n");
+    add_message_to_queue(reply, strsz);
+    free(reply);
+    reply = NULL;
+    return;
+  }
+
+  if (strlen(command) < strlen( bot_commands[CMD_ID_ACTION_SAY_TEXT].cmd) + 1)
+  {
+    strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE,
+                     "Please enter text for me to say!\n");
+  }
+  else
+  {
+    strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE,
+                     "%s\n", (command + strlen(bot_commands[CMD_ID_ACTION_SAY_TEXT].cmd)));
+  }
+  add_message_to_queue(reply, strsz);
+  free(reply);
+  reply = NULL;
+}

--- a/recipes-modem/openqti/files/src/command.c
+++ b/recipes-modem/openqti/files/src/command.c
@@ -468,6 +468,9 @@ uint8_t parse_command(uint8_t *command) {
   case CMD_ID_ACTION_INTERNAL_NETWORK_SET_AUTH_METHOD:
     cmd_configure_internal_network_auth_method(command);
     break;
+  case CMD_ID_ACTION_SAY_TEXT: /* Say X */
+    cmd_say_text(command);
+    break;
   case CMD_UNKNOWN:
   default:
     strsz = snprintf((char *)reply, MAX_MESSAGE_SIZE,


### PR DESCRIPTION
The 'say X' command is simple, the modem just responds with X. If you are not in a call with the modem, it responds via SMS. If you are in a call in the modem, it responds via Text To Speech. If you don't give it anything to say, it responds with "Please enter text for me to say!"

The main use is the TTS response so that you can make the modem say whatever.

 Examples:
- say Hello
- say I am a robot
- say Look, I can make my modem say things!